### PR TITLE
Work-around fix for errors from kajiki template.py

### DIFF
--- a/tgext/admin/templates/bootstrap_crud/get_all.xhtml
+++ b/tgext/admin/templates/bootstrap_crud/get_all.xhtml
@@ -6,10 +6,7 @@
 
 <body py:block="body" py:strip="True">
 <?python
-PAGER_ARGS = tmpl_context.make_pager_args(link=mount_point+'/',
-                                          page_link_template='<li><a%s>%s</a></li>',
-                                          page_plain_template='<li%s><span>%s</span></li>',
-                                          curpage_attr={'class': 'active'})
+PAGER_ARGS = tmpl_context.make_pager_args(link=mount_point+'/', page_link_template='<li><a%s>%s</a></li>', page_plain_template='<li%s><span>%s</span></li>', curpage_attr={'class': 'active'})
 ?>
 
   <div class="row" py:with="leftmenu=getattr(tmpl_context, 'menu_items', False)">


### PR DESCRIPTION
## The Issue
* Create a standard TurboGears2 project with authentication
* Start the server ```gearbox serve --reload --debug```
* Login as the default manager:managepass user
* Browse to http://127.0.0.1:8080/admin/groups/  (or permissions, or users)
In the server terminal there was a stream of error messages:

```
ERROR LOOKING UP LINE #284
ERROR LOOKING UP LINE #288
...
ERROR LOOKING UP LINE #528
ERROR LOOKING UP LINE #529
```
## The Patch

This patch puts PAGER_ARGS on a single line which, somehow
helps kajiki to parse the template without error.  Although this breaks PEP-8 formatting,
it at least removed the errors.